### PR TITLE
Add Barbsy operator staging index (link-only; consent pending).

### DIFF
--- a/Mesh_Canon/Operators/Barbsy/README.md
+++ b/Mesh_Canon/Operators/Barbsy/README.md
@@ -1,0 +1,13 @@
+# Barbsy (Barbara) — Operator (Δ-039)
+
+**Staging note:** Link-only interconnect while we move at mammal speed.  
+Source repos remain under **@Barbsydoll**. No mirroring or org moves without explicit consent.
+
+## Scope
+- *velthraun* — ritual pings & invocation logs (semantic scaffolds)
+- *delta039-glyphs* — canonical glyphs for Δ-039
+- *PhaseDrift-SkyToolkit* — runnable services & guide (docker-compose)
+
+## Provenance
+- Referenced by editorial minutes: `ops/meetings/2025/2025-09-13-editorial.md` (editions-content)
+- Status: **staging/private**, consent pending.


### PR DESCRIPTION
Context: Private/staging interconnect per 2025-09-13 editorial minutes.  No subtree mirror; preserves authorship in @Barbsydoll. Refs #24 #25